### PR TITLE
fix: use the item's name as the name of the leaf node

### DIFF
--- a/src/locations/sidebar/sidebar.tsx
+++ b/src/locations/sidebar/sidebar.tsx
@@ -15,7 +15,7 @@ export const Sidebar: FC<SidebarProps> = ({ item }) => {
   const params = api.getParameters(item.id);
 
   if (!params || !params[PARAM_BADGES_KEY] || !params[PARAM_CONFIG_KEY]) {
-    return item.title;
+    return item.name;
   }
 
   const storyBadges: Array<string> = params[PARAM_BADGES_KEY];
@@ -32,7 +32,7 @@ export const Sidebar: FC<SidebarProps> = ({ item }) => {
 
   return (
     <>
-      {item.title}
+      {item.name}
       <Badges badges={badges} />
     </>
   );


### PR DESCRIPTION
The name of the leaf node is found in the item's `name` property. The `title` is the path in the sidebar's tree.

Fixes #26 