### PR TITLE
Prevent unwanted badge wrap by modifying overflow behaviour

### DIFF
--- a/src/components/badge.component.tsx
+++ b/src/components/badge.component.tsx
@@ -23,6 +23,9 @@ export const StyledBadge = styled.span<StyledBadgeProps>(
     textTransform: styles?.textTransform || "uppercase",
     paddingInline: styles?.paddingInline || "5px",
     paddingBlock: styles?.paddingBlock || "2px",
+    whiteSpace: styles?.whiteSpace || "nowrap",
+    overflow: styles?.overflow || "hidden",
+    textOverflow: styles?.textOverflow || "ellipsis",
     display: "block",
   }),
 );

--- a/src/typings.interface.ts
+++ b/src/typings.interface.ts
@@ -21,6 +21,9 @@ export type BadgeConfig = {
         paddingBlock?: Property.PaddingBlock,
         paddingInline?: Property.PaddingInline,
         textTransform?: Property.TextTransform,
+        whiteSpace?: Property.WhiteSpace,
+        overflow?: Property.Overflow,
+        textOverflow?: Property.TextOverflow,
     };
     location?: Array<'toolbar' | 'toolbar-extra' | 'sidebar'>;
     title?: string;


### PR DESCRIPTION
# Context

👋 Hi there, I recently noticed the following not-so-optimal behaviour for long badges, or short ones in deeply nested components.

![CleanShot 2024-12-09 at 16 39 58@2x](https://github.com/user-attachments/assets/63ecbd67-131a-4695-bebb-81615b66f557)

This PR includes a quick fix, while still allowing anyone to customise the overridden style properties (cf. changes in `typings.interface.ts`)

# Copilot summary

This pull request includes changes to enhance the styling capabilities of the `StyledBadge` component by adding new properties to control text overflow behavior. The most important changes are:

Styling enhancements for `StyledBadge` component:

* [`src/components/badge.component.tsx`](diffhunk://#diff-14a649825aeb6206c731bca7e6b6deb2d7696d240e3564d968aabaf4cc897471R26-R28): Added `whiteSpace`, `overflow`, and `textOverflow` properties to the `StyledBadge` component to handle text overflow and ensure proper display.
* [`src/typings.interface.ts`](diffhunk://#diff-c06a49552d6f4f5294c6ebb122c78aa4f2eecf384a979245e03ebc1973e421feR24-R26): Updated the `BadgeConfig` type to include the new `whiteSpace`, `overflow`, and `textOverflow` properties for better type safety and configuration.